### PR TITLE
Add Zotero 10 WebDAV compatibility

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -55,4 +55,24 @@ async function shutdown({ id, version, resourceURI, rootURI }, reason) {
   }
 }
 
-async function uninstall(data, reason) { }
+function uninstall(data, reason) {
+  // Preserve the WebDAV settings managed by Zotero itself, but remove the
+  // plugin's own authorization and state when the user explicitly uninstalls.
+  if (reason !== ADDON_UNINSTALL) {
+    return;
+  }
+
+  const prefsPrefix = "extensions.zotero.zotero-plugin-nutstore";
+  const pluginPrefs = [
+    "nutstore-sso-token",
+    "nutstore-webdav-force-set",
+    "nutstore-env-mode",
+  ];
+
+  for (const key of pluginPrefs) {
+    const pref = `${prefsPrefix}.${key}`;
+    if (Services.prefs.prefHasUserValue(pref)) {
+      Services.prefs.clearUserPref(pref);
+    }
+  }
+}

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "7.0",
-      "strict_max_version": "9.*"
+      "strict_max_version": "10.*"
     }
   }
 }

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,4 +1,4 @@
 /* eslint-disable no-undef */
 pref('nutstore-env-mode', 'sso')
 pref('nutstore-sso-token', '')
-pref('nutstore-webdav-force-set', true)
+pref('nutstore-webdav-force-set', false)

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,5 @@
 import { startupVerifyEnhancedWebdav } from './modules/enhanced-webdav'
-import { registerNutstoreSSOProtocol } from './modules/nutstore-sso'
+import { registerNutstoreSSOProtocol, unregisterNutstoreSSOProtocol } from './modules/nutstore-sso'
 import { registerPerfObserver, registerPrefs, registerPrefsScripts } from './modules/preference'
 import { initLocale } from './utils/locale'
 import { createZToolkit } from './utils/ztoolkit'
@@ -47,6 +47,7 @@ async function onMainWindowUnload(win: _ZoteroTypes.MainWindow): Promise<void> {
 }
 
 function onShutdown(): void {
+  unregisterNutstoreSSOProtocol()
   ztoolkit.unregisterAll()
   addon.data.dialog?.window?.close()
   // Remove addon object

--- a/src/modules/enhanced-webdav.ts
+++ b/src/modules/enhanced-webdav.ts
@@ -5,7 +5,7 @@ import { getEnhancedConfig } from '../utils/enhanced-config'
 import { getString } from '../utils/locale'
 import { reInitZoteroSync } from '../utils/nutstore'
 import { getPrefWin } from '../utils/prefs'
-import { setWebdavPassword } from '../utils/zotero-compat'
+import { prepareWebdavConfigurationChange, setWebdavPassword } from '../utils/zotero-compat'
 import { isSyncStorageEnabled } from '../utils/ztoolkit'
 import { forceSetNutstoreWebdavPerfs } from './nutstore-sso'
 
@@ -54,14 +54,15 @@ export function showNutstoreSSOWebdav() {
 }
 
 export async function setEnhanceWebdav(config: EnhancedWebdavConfig) {
+  prepareWebdavConfigurationChange()
+
   Zotero.Prefs.set('sync.storage.protocol', 'webdav')
   Zotero.Prefs.set('sync.storage.scheme', config.WebDavServer.Scheme)
   Zotero.Prefs.set('sync.storage.username', config.WebDavServer.Credentials.Username)
   Zotero.Prefs.set('sync.storage.url', config.WebDavServer.Url)
 
   await setWebdavPassword(config.WebDavServer.Credentials.Password)
-
-  reInitZoteroSync()
+  await reInitZoteroSync()
 }
 
 export async function ensureEnhancedWebdav(config: EnhancedWebdavConfig) {

--- a/src/modules/nutstore-sso.ts
+++ b/src/modules/nutstore-sso.ts
@@ -3,9 +3,9 @@ import { getElementById, hideElement, showElement } from '../utils/dom'
 import { clearStoragePasswordInputValue, getNutstoreWebdavUrl, isNutstoreWebdav, reInitZoteroSync } from '../utils/nutstore'
 import { getPref, getPrefWin, setPref } from '../utils/prefs'
 import { decryptToken } from '../utils/sso'
-import { getWebdavPassword, setWebdavPassword } from '../utils/zotero-compat'
+import { getWebdavPassword, prepareWebdavConfigurationChange, setWebdavPassword } from '../utils/zotero-compat'
 
-export { registerNutstoreSSOProtocol } from './protocol'
+export { registerNutstoreSSOProtocol, unregisterNutstoreSSOProtocol } from './protocol'
 
 export async function updateNutstoreSSOPerfs() {
   const prefWin = getPrefWin()
@@ -98,6 +98,8 @@ export async function clearNutstoreWebdavPerfs() {
   if (!isNutstoreWebdav())
     return
 
+  prepareWebdavConfigurationChange()
+
   Zotero.Prefs.set('sync.storage.username', '')
   Zotero.Prefs.set('sync.storage.url', '')
   await setWebdavPassword('')
@@ -113,14 +115,15 @@ export async function forceSetNutstoreWebdavPerfs() {
   if (!oauthInfo)
     return
 
+  prepareWebdavConfigurationChange()
+
   Zotero.Prefs.set('sync.storage.enabled', true)
   Zotero.Prefs.set('sync.storage.protocol', 'webdav')
   Zotero.Prefs.set('sync.storage.scheme', 'https')
   Zotero.Prefs.set('sync.storage.username', oauthInfo.username)
   Zotero.Prefs.set('sync.storage.url', getNutstoreWebdavUrl())
   await setWebdavPassword(oauthInfo.access_token)
-
-  reInitZoteroSync()
+  await reInitZoteroSync()
 
   setPref('nutstore-webdav-force-set', true)
   updateNutstoreSSOPerfs()

--- a/src/modules/protocol.ts
+++ b/src/modules/protocol.ts
@@ -1,7 +1,7 @@
 import type { ProtocolExtension } from '../utils/protocol'
 import { getString } from '../utils/locale'
 import { setPref } from '../utils/prefs'
-import { registerCustomProtocolPath } from '../utils/protocol'
+import { registerCustomProtocolPath, unregisterCustomProtocolPath } from '../utils/protocol'
 import { decryptToken } from '../utils/sso'
 import { forceSetNutstoreWebdavPerfs, updateNutstoreSSOPerfs } from './nutstore-sso'
 
@@ -20,8 +20,27 @@ class SSOProtocol implements ProtocolExtension {
   }
 }
 
+let registeredSSOProtocol: SSOProtocol | undefined
+
 export function registerNutstoreSSOProtocol() {
-  registerCustomProtocolPath('nutstore-sync', new SSOProtocol())
+  if (registeredSSOProtocol)
+    return
+
+  const protocol = new SSOProtocol()
+  if (registerCustomProtocolPath('nutstore-sync', protocol)) {
+    registeredSSOProtocol = protocol
+  }
+  else {
+    ztoolkit.log('[Nutstore SSO] unable to register zotero://nutstore-sync protocol handler')
+  }
+}
+
+export function unregisterNutstoreSSOProtocol() {
+  if (!registeredSSOProtocol)
+    return
+
+  unregisterCustomProtocolPath('nutstore-sync', registeredSSOProtocol)
+  registeredSSOProtocol = undefined
 }
 
 async function onNutstoreSSOProtocolCall(token: string) {

--- a/src/utils/nutstore.ts
+++ b/src/utils/nutstore.ts
@@ -1,5 +1,6 @@
 import { getElement } from './dom'
 import { getPrefWin } from './prefs'
+import { getWebdavPassword } from './zotero-compat'
 
 export function getNutstoreWebdavUrl() {
   return addon.data.env === 'development' ? 'dav-demo.jianguoyun.com/dav' : 'dav.jianguoyun.com/dav'
@@ -14,21 +15,33 @@ export function isNutstoreWebdav() {
   return currentSyncEnabled && currentSyncProtocol === 'webdav' && currentSyncScheme === 'https' && currentSyncUrl === getNutstoreWebdavUrl()
 }
 
-export function reInitZoteroSync() {
+/**
+ * Refresh the native storage settings UI after a plugin-driven configuration
+ * change without rerunning Zotero 10's heavier Account-pane initialization.
+ */
+export async function reInitZoteroSync() {
   const win = getPrefWin()
-  if (!win)
+  const sync = win?.Zotero_Preferences?.Sync
+  if (!win || !sync)
     return
 
-  if (win.Zotero_Preferences.Sync) {
-    win.Zotero_Preferences.Sync.init()
+  if (Number.parseInt(Zotero.version, 10) >= 10) {
+    await sync.updateStorageSettingsUI?.()
+    const passwordInput = getElement('#storage-password', win.document) as HTMLInputElement
+    if (passwordInput)
+      passwordInput.value = await getWebdavPassword()
+    sync.storeLastStorageSettings?.()
+    return
   }
+
+  await sync.init?.()
 }
 
 export function clearStoragePasswordInputValue() {
   const win = getPrefWin()
   if (!win)
     return
-  const passwordInput = getElement(`vbox#zotero-prefpane-sync input#storage-password`, win.document) as HTMLInputElement
+  const passwordInput = getElement('#storage-password', win.document) as HTMLInputElement
 
   if (passwordInput) {
     passwordInput.value = ''

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -1,8 +1,50 @@
 const ZOTERO_SCHEME = 'zotero'
 
-export function registerCustomProtocolPath(path: string, ext: ProtocolExtension) {
-  const protocolHandler = Services.io.getProtocolHandler(ZOTERO_SCHEME)
-  ;(protocolHandler as any).wrappedJSObject._extensions[`${ZOTERO_SCHEME}://${path}`] = ext
+type ProtocolExtensions = Record<string, ProtocolExtension>
+
+function getCustomProtocolExtensions(): ProtocolExtensions | undefined {
+  try {
+    const protocolHandler = Services.io.getProtocolHandler(ZOTERO_SCHEME) as any
+    const extensions = protocolHandler.wrappedJSObject?._extensions
+    return extensions && typeof extensions === 'object'
+      ? extensions as ProtocolExtensions
+      : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function registerCustomProtocolPath(path: string, ext: ProtocolExtension): boolean {
+  const extensions = getCustomProtocolExtensions()
+  const uri = `${ZOTERO_SCHEME}://${path}`
+
+  if (!extensions)
+    return false
+
+  try {
+    if (extensions[uri] && extensions[uri] !== ext)
+      return false
+
+    extensions[uri] = ext
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+export function unregisterCustomProtocolPath(path: string, ext: ProtocolExtension): void {
+  const extensions = getCustomProtocolExtensions()
+  const uri = `${ZOTERO_SCHEME}://${path}`
+
+  try {
+    if (extensions?.[uri] === ext)
+      delete extensions[uri]
+  }
+  catch {
+    // Ignore failures from Zotero's private protocol extension registry.
+  }
 }
 
 export interface ProtocolExtension {

--- a/src/utils/zotero-compat.ts
+++ b/src/utils/zotero-compat.ts
@@ -1,5 +1,5 @@
 /**
- * Compatibility layer for Zotero 7/8/9
+ * Compatibility layer for Zotero 7–10
  * Handles differences in WebDAV password API between versions
  */
 
@@ -13,14 +13,14 @@ interface WebDavControllerModern {
 }
 
 /**
- * Get WebDAV password with compatibility for Zotero 7/8/9
+ * Get WebDAV password with compatibility for Zotero 7–10
  * Zotero 7: Uses synchronous property controller.password
  * Zotero 8/9: Uses async method controller.getPassword()
  */
 export async function getWebdavPassword(): Promise<string> {
   const controller = Zotero.Sync.Runner.getStorageController('webdav')
 
-  // Check modern API (Zotero 8/9)
+  // Check modern API (Zotero 8+)
   if ('getPassword' in controller && typeof controller.getPassword === 'function') {
     return await (controller as WebDavControllerModern).getPassword()
   }
@@ -30,14 +30,14 @@ export async function getWebdavPassword(): Promise<string> {
 }
 
 /**
- * Set WebDAV password with compatibility for Zotero 7/8/9
+ * Set WebDAV password with compatibility for Zotero 7–10
  * Zotero 7: Uses synchronous property controller.password = value
  * Zotero 8/9: Uses async method controller.setPassword(value)
  */
 export async function setWebdavPassword(password: string): Promise<void> {
   const controller = Zotero.Sync.Runner.getStorageController('webdav')
 
-  // Check modern API (Zotero 8/9)
+  // Check modern API (Zotero 8+)
   if ('setPassword' in controller && typeof controller.setPassword === 'function') {
     await (controller as WebDavControllerModern).setPassword(password)
   }
@@ -45,4 +45,23 @@ export async function setWebdavPassword(password: string): Promise<void> {
     // Zotero 7 (password property)
     (controller as WebDavControllerLegacy).password = password
   }
+}
+
+/**
+ * Discard a cached WebDAV controller before changing its settings.
+ *
+ * Zotero caches storage controllers. Zotero 10 resets this cache when the
+ * WebDAV server settings change, so the next password write uses a controller
+ * created from the new preferences. The optional calls preserve the existing
+ * behavior on older Zotero versions where either method is unavailable.
+ */
+export function prepareWebdavConfigurationChange(): void {
+  const runner = Zotero.Sync.Runner as typeof Zotero.Sync.Runner & {
+    resetStorageController?: (mode: 'webdav') => void
+  }
+  const controller = runner.getStorageController('webdav')
+
+  controller.clearCachedCredentials?.()
+  Zotero.Prefs.set('sync.storage.verified', false)
+  runner.resetStorageController?.('webdav')
 }


### PR DESCRIPTION
## Summary

This PR adds Zotero 10 compatibility for Nutstore WebDAV configuration and fixes a few related plugin-state lifecycle issues.

- Support Zotero 10's cached WebDAV storage controller lifecycle when changing WebDAV settings
- Refresh the Zotero 10 Account storage UI without rerunning the full `Sync.init()` flow
- Preserve the existing Zotero 7–9 behavior
- Clean up the private `zotero://nutstore-sync` route on plugin shutdown without affecting routes owned by other instances
- Make the WebDAV ownership marker default to `false` and clear plugin-owned preferences only on explicit uninstall

## WebDAV configuration changes

Before changing WebDAV settings, the plugin now:

1. Clears cached credentials from the current WebDAV controller when available
2. Marks storage verification as incomplete
3. Resets the cached WebDAV controller when supported
4. Writes the new preferences and password through the existing compatibility helper

This ensures the password is written through a controller created from the new configuration.

For Zotero 10, the Account storage UI is refreshed with `updateStorageSettingsUI()` instead of rerunning `Sync.init()`. The WebDAV password field is then populated from Zotero's credential store, and the current settings are recorded.

## State and lifecycle behavior

- Explicit uninstall removes only plugin-owned preferences:
  - `nutstore-sso-token`
  - `nutstore-webdav-force-set`
  - `nutstore-env-mode`
- Disable and upgrade preserve plugin state.
- Zotero-managed WebDAV settings and credentials are never removed by uninstall.
- The SSO protocol route is removed only when it still belongs to this plugin instance.
- If Zotero's private protocol registry is unavailable or not writable, SSO callback registration fails gracefully while other plugin initialization can continue.

## Validation

- `node --check addon/bootstrap.js`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint .`
- `git diff --check`

Manual checks:

- Explicit uninstall clears the three plugin-owned preferences.
- Disabling the plugin preserves them.
- Updating an installed prior version to a build containing these changes preserves the SSO token.